### PR TITLE
DRY stage.rb files into deploy.rb

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -59,7 +59,7 @@ namespace :deploy do
     on roles(:web) do
       dirs = linked_dirs(shared_path) << File.join(shared_path, "config")
       dirs.each do |dir|
-        if test :test, '-0', dir
+        if test :test, '-O', dir
           execute :chmod, '2775', dir
         end
       end
@@ -70,7 +70,7 @@ namespace :deploy do
     on roles(:web) do
       files = linked_files(shared_path)
       files.each do |file|
-        if test :test, '-0', file
+        if test :test, '-O', file
           execute :chmod, '0660', file
         end
       end
@@ -81,7 +81,7 @@ namespace :deploy do
     on roles(:web) do
       assets_dir = File.join(shared_path,"public","assets", "**")
       Dir.glob(assets_dir).each do |file|
-        if test :test, '-0', file
+        if test :test, '-O', file
           execute :chmod, '2775', file
         end
       end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -7,17 +7,39 @@ lock '~> 3.4'
 
 set :application, 'myapp'
 set :repo_url, 'https://github.com/myorganization/myapp.git'
+
+set :linked_files, %w{bundle/config .ruby-version}
+set :config_files, %w{config/database.yml config/secrets.yml     config/puma.rb      config/fedora.yml
+                      config/ezid.yml     config/blacklight.yml  config/solr.yml     config/zotero.yml
+                      config/redis.yml    config/resque-pool.yml config/role_map.yml config/arkivo.yml
+                      config/mcommunity.yml config/browse_everything_providers.yml}
+
+set :linked_dirs,  %w{log bundle tmp/pids tmp/cache tmp/derivatives tmp/uploads
+                      tmp/sockets vendor/bundle public/system public/uploads}
+
+############## Most users should not need to set anything below this line. ##############
+
 set :scm, :git
 set :format, :pretty
 set :pty, true
 set :use_sudo, false
 set :deploy_via, :remote_cache
+
 set :rbenv_map_bins, %w{rake gem bundle ruby rails}
+set :rbenv_custom_path, '/l/local/rbenv'
+set :rbenv_ruby, '2.3.0'
+set :rbenv_type, :system
+set :rbenv_prefix, ->{"RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec"}
+
+set :deploy_to, ->{ File.join fetch(:deploy_base), "#{fetch(:application)}-#{fetch(:stage)}" }
+set :default_env, ->{ { 'HOME' => shared_path } }
+set :bundle_path, ->{ shared_path.join('vendor/bundle') }
 
 # Support multiple users running the deployment (not simultaneously though!!)
 # Set umask so files are group writeable.
 SSHKit.config.umask = '0002'
-# Set :tmp_dir so multiple users can run the deplyment
+
+# Set :tmp_dir so multiple users can run the deployment
 set :tmp_dir, File.join('/tmp', ENV['USER'] )
 
 # Use branch from env if provided.
@@ -66,16 +88,19 @@ namespace :deploy do
     end
   end
 
+  task :restart do
+    on roles(:web) do
+      # This has to be enabled using visudo on the server
+      execute :sudo, '/bin/systemctl', 'restart', "app-puma@#{fetch(:application)}-#{fetch(:stage)}.service"
+    end
+  end
+
+  before :starting, "linked_files:upload:files"
   before :starting, :create_dirs
   before :starting, :chmod_dirs
   after :updated, :chmod_assets
+  after :finishing, :cleanup
+  after :finishing, :restart
 
-  after :restart, :clear_cache do
-    on roles(:web), in: :groups, limit: 3, wait: 10 do
-      # Here we can do anything such as:
-      # within release_path do
-      #   execute :rake, 'cache:clear'
-      # end
-    end
-  end
 end
+

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -10,37 +10,7 @@ server 'production-server.organization.org',
 set :user, 'myapp-production'
 set :stage, :production
 set :rails_env, 'production'
-set :deploy_to, '/hydra/myapp-production'
-set :default_env, { 'HOME' => '/hydra/myapp-production/shared'}
+set :deploy_base, '/hydra'
 set :log_level, :debug
 set :keep_releases, 3
-set :rbenv_custom_path, '/l/local/rbenv'
-set :rbenv_ruby, '2.3.0'
-set :rbenv_type, :system
-set :rbenv_prefix, "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec"
-
-set :linked_files, %w{bundle/config .ruby-version} 
-set :config_files, %w{config/database.yml config/secrets.yml     config/puma.rb      config/fedora.yml
-                      config/ezid.yml     config/blacklight.yml  config/solr.yml     config/zotero.yml
-                      config/redis.yml    config/resque-pool.yml config/role_map.yml config/arkivo.yml
-                      config/mcommunity.yml config/browse_everything_providers.yml}
-
-set :linked_dirs,  %w{log bundle tmp/pids tmp/cache tmp/derivatives tmp/uploads tmp/sockets vendor/bundle public/system public/uploads}
-
-set :bundle_path, -> { shared_path.join('vendor/bundle') }
 set :bundle_flags, '--quiet --deployment'
-
-namespace :deploy do
-  task :restart do
-    on roles(:web) do
-      # This has to be enabled using visudo on the server
-      execute :sudo, '/bin/systemctl', 'restart', 'app-puma@myapp-production.service'
-    end
-  end
-
-  # Set the stage so config_files gets the correct stage
-  before :starting, "linked_files:upload:files"
-  after :finishing, :compile_assets
-  after :finishing, :cleanup
-  after :finishing, :restart
-end

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -10,37 +10,7 @@ server 'staging-server.organization.org',
 set :user, 'myapp-staging'
 set :stage, :staging
 set :rails_env, 'production'
-set :deploy_to, '/hydra-dev/myapp-staging'
-set :default_env, { 'HOME' => '/hydra-dev/myapp-staging/shared'}
+set :deploy_base, '/hydra-dev'
 set :log_level, :debug
 set :keep_releases, 3
-set :rbenv_custom_path, '/l/local/rbenv'
-set :rbenv_ruby, '2.3.0'
-set :rbenv_type, :system
-set :rbenv_prefix, "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec"
-
-set :linked_files, %w{bundle/config .ruby-version} 
-set :config_files, %w{config/database.yml config/secrets.yml     config/puma.rb      config/fedora.yml
-                      config/ezid.yml     config/blacklight.yml  config/solr.yml     config/zotero.yml
-                      config/redis.yml    config/resque-pool.yml config/role_map.yml config/arkivo.yml
-                      config/mcommunity.yml config/browse_everything_providers.yml}
-
-set :linked_dirs,  %w{log bundle tmp/pids tmp/cache tmp/derivatives tmp/uploads tmp/sockets vendor/bundle public/system public/uploads}
-
-set :bundle_path, -> { shared_path.join('vendor/bundle') }
 set :bundle_flags, '--quiet --deployment'
-
-namespace :deploy do
-  task :restart do
-    on roles(:web) do
-      # This has to be enabled using visudo on the server
-      execute :sudo, '/bin/systemctl', 'restart', 'app-puma@myapp-staging.service'
-    end
-  end
-
-  # Set the stage so config_files gets the correct stage
-  before :starting, "linked_files:upload:files"
-  after :finishing, :compile_assets
-  after :finishing, :cleanup
-  after :finishing, :restart
-end


### PR DESCRIPTION
- Do as much work as possible in deploy.rb, reducing individual stage files to minimal configuration.
- replace :deploy_to, :deploy_env with :deploy_base; move functionality to common deploy.rb